### PR TITLE
ci: fix gh cli authentication token

### DIFF
--- a/.github/workflows/security-scanners.yml
+++ b/.github/workflows/security-scanners.yml
@@ -42,5 +42,5 @@ jobs:
 
       - name: Create Issues and Ping Contributor
         env:
-          GITHUB_TOKEN: $\{{ secrets.GITHUB_TOKEN \}}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python3 tools/bots/vuln_reporter.py


### PR DESCRIPTION
Change GITHUB_TOKEN to GH_TOKEN so the gh CLI can authenticate to create issues