### PR TITLE
ci: restrict critical directory edits to admins

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+.github/ @CodNoob100
+tools/bots/ @CodNoob100
+protection.json @CodNoob100

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -41,7 +41,7 @@ jobs:
             "enforce_admins": true,
             "required_pull_request_reviews": {
               "dismiss_stale_reviews": false,
-              "require_code_owner_reviews": false,
+              "require_code_owner_reviews": true,
               "required_approving_review_count": 0
             },
             "restrictions": null,
@@ -59,12 +59,12 @@ jobs:
           fetch-depth: 0
 
       - name: Restrict Workflow and Bot Edits
-        if: github.event_name == 'pull_request' && !contains(fromJSON('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.pull_request.author_association)
+        if: github.event_name == 'pull_request' && github.event.pull_request.author_association != 'OWNER'
         run: |
           git fetch origin main
           CHANGED_FILES=$(git diff --name-only origin/main...HEAD)
-          if echo "$CHANGED_FILES" | grep -qE '^(\.github/workflows/|tools/bots/)'; then
-            echo "ERROR: You do not have permission to modify CI workflows or bots."
+          if echo "$CHANGED_FILES" | grep -qE '^(\.github/|tools/bots/|protection\.json)'; then
+            echo "ERROR: Only the repository admin (OWNER) can modify .github, tools/bots, or protection.json."
             exit 1
           fi
 


### PR DESCRIPTION
Introduces a CODEOWNERS file and updates branch protection to block contributors from editing \.github\, \	ools/bots\, and \protection.json\.