### PR TITLE
ci: whitelist dependabot

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -59,7 +59,7 @@ jobs:
           fetch-depth: 0
 
       - name: Restrict Workflow and Bot Edits
-        if: github.event_name == 'pull_request' && github.event.pull_request.author_association != 'OWNER'
+        if: github.event_name == 'pull_request' && github.event.pull_request.author_association != 'OWNER' && github.actor != 'dependabot[bot]'
         run: |
           git fetch origin main
           CHANGED_FILES=$(git diff --name-only origin/main...HEAD)


### PR DESCRIPTION
Allows dependabot to update github actions workflows.