### PR TITLE
ci: disable admin enforcement

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -38,7 +38,7 @@ jobs:
               "strict": true,
               "contexts": ["Contributing Rules Bot"]
             },
-            "enforce_admins": true,
+            "enforce_admins": false,
             "required_pull_request_reviews": {
               "dismiss_stale_reviews": false,
               "require_code_owner_reviews": true,


### PR DESCRIPTION
Disables admin enforcement so the repository owner can forcefully merge Dependabot PRs that are incorrectly stuck on the CLA bot.