### PR TITLE
add health endpoint to Rust daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Added
+
+- `/health` endpoint to the `nulld` daemon returning HTTP 200 with `{"status": "ok"}` for Docker/Kubernetes readiness probes.

--- a/crates/nulld/src/main.rs
+++ b/crates/nulld/src/main.rs
@@ -137,6 +137,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let state = Arc::new(global_state);
 
     let app = Router::new()
+        .route("/health", get(handle_health))
         .route("/inject", post(handle_inject))
         .route("/recall", get(handle_recall))
         .route("/snapshot", post(handle_snapshot))
@@ -152,6 +153,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let listener = tokio::net::TcpListener::bind(bind_addr).await?;
     axum::serve(listener, app).await?;
     Ok(())
+}
+
+async fn handle_health() -> impl IntoResponse {
+    (
+        StatusCode::OK,
+        Json(SimpleResponse {
+            status: "ok".to_string(),
+        }),
+    )
 }
 
 async fn get_or_load_thread(


### PR DESCRIPTION
Add a /health endpoint to the Rust Daemon

Closes #1 